### PR TITLE
Added Row/Column limit feature in Vertical/Horizontal layouts

### DIFF
--- a/src/js/layout/base.js
+++ b/src/js/layout/base.js
@@ -89,6 +89,15 @@ function ($) {
             }
 
             return intersection;
+        },
+        
+        /**
+         * ### @isLimitable
+         * Returns whether rows/colums in layout are limitable
+         * If yes, should implement a setLimit method
+         */
+        isLimitable : function() {
+            return false;
         }
     };
 

--- a/src/js/layout/horizontal.js
+++ b/src/js/layout/horizontal.js
@@ -55,12 +55,14 @@ function ($, util, BaseLayout) {
                 i = 0, 
                 j =0;
             
-            if(cols>0) {
+            if(cols>0 && cols<sprites.length) {
                 rows = Math.ceil(sprites.length/cols);
                 for(i=0; i<rows; i++) {
                     for(j=0; j<cols; j++) {
-                        if(sprites[i*cols+j])
-                        minwidth += sprites[i*cols+j].width; 
+                        if(sprites[i*cols+j]) {
+                            minwidth += sprites[i*cols+j].width;
+                            height += sprites[i*rows+j].height;
+                        }
                     }
                     width = Math.max(width, minwidth);
                     minwidth = 0;    

--- a/src/js/layout/horizontal.js
+++ b/src/js/layout/horizontal.js
@@ -61,7 +61,7 @@ function ($, util, BaseLayout) {
                     for(j=0; j<cols; j++) {
                         if(sprites[i*cols+j]) {
                             minwidth += sprites[i*cols+j].width;
-                            height += sprites[i*rows+j].height;
+                            height += sprites[i*cols+j].height;
                         }
                     }
                     width = Math.max(width, minwidth);

--- a/src/js/layout/horizontal.js
+++ b/src/js/layout/horizontal.js
@@ -48,12 +48,29 @@ function ($, util, BaseLayout) {
         getDimensions: function (sprites, defaults) {
             var width = 0;
             var height = 0;
-
-            $.map(sprites, function (sprite) {
+            
+            var cols = this.columnlimit || 0,
+                rows = 0,
+                minwidth = 0, 
+                i = 0, 
+                j =0;
+            
+            if(cols>0) {
+                rows = Math.ceil(sprites.length/cols);
+                for(i=0; i<rows; i++) {
+                    for(j=0; j<cols; j++) {
+                        if(sprites[i*cols+j])
+                        minwidth += sprites[i*cols+j].width; 
+                    }
+                    width = Math.max(width, minwidth);
+                    minwidth = 0;    
+                }
+            }
+            else $.map(sprites, function (sprite) {
                 height = sprite.height > height ? sprite.height : height;
                 width += sprite.width;
             });
-
+            
             return {
                 width: width || defaults.width,
                 height: height || defaults.height
@@ -76,28 +93,48 @@ function ($, util, BaseLayout) {
             var pass = 0;
             var x = 0;
             var y = 0;
-
+            
             while (pass++ < this.settings.maxPass) {
-                for (x = 0; x <= dimensions.width - sprite.width; x++) {
-                    sprite.x = x;
-                    sprite.y = y;
+                for (y = 0; y <= dimensions.height - sprite.height; y++) {
+                    for (x = 0; x <= dimensions.width - sprite.width; x++) {
+                        sprite.x = x;
+                        sprite.y = y;
 
-                    intersection = this.intersection(sprite, placed);
+                        intersection = this.intersection(sprite, placed);
 
-                    if (!intersection) {
-                        placed.push(sprite);
-                        sprite.show();
-                        return true;
-                    }
+                        if (!intersection) {
+                            placed.push(sprite);
+                            sprite.show();
+                            return true;
+                        }
 
-                    x = intersection.x + intersection.width - 1;
+                        x = intersection.x + intersection.width - 1;
+                    } 
+                    
+                    y = intersection.y + intersection.height - 1;
                 }
-
+                
                 dimensions.width += sprite.width;
                 dimensions.height += sprite.height;
             }
 
             return false;
+        },
+        
+        /**
+         * ### @isLimitable
+         * Returns whether rows/colums in layout are limitable
+         */
+        isLimitable : function() {
+            return true;
+        },
+        
+        /**
+         * ### @setLimit
+         * Limit the number of columns
+         */
+        setLimit : function(limit) {
+            this.columnlimit = limit;
         }
     });
 

--- a/src/js/layout/vertical.js
+++ b/src/js/layout/vertical.js
@@ -49,7 +49,24 @@ function ($, util, BaseLayout) {
             var width = 0;
             var height = 0;
 
-            $.map(sprites, function (sprite) {
+            var rows = this.rowlimit || 0,
+                cols = 0,
+                minheight = 0, 
+                i = 0, 
+                j =0;
+                
+            if(rows>0) {
+                cols = Math.ceil(sprites.length/rows);
+                for(i=0; i<cols; i++) {
+                    for(j=0; j<rows; j++) {
+                        if(sprites[i*rows+j])
+                        minheight += sprites[i*rows+j].height; 
+                    }
+                    height = Math.max(height, minheight);
+                    minheight = 0;    
+                }
+            }
+            else $.map(sprites, function (sprite) {
                 width = sprite.width > width ? sprite.width : width;
                 height += sprite.height;
             });
@@ -78,19 +95,23 @@ function ($, util, BaseLayout) {
             var y = 0;
 
             while (pass++ < this.settings.maxPass) {
-                for (y = 0; y <= dimensions.height - sprite.height; y++) {
-                    sprite.x = x;
-                    sprite.y = y;
+                for (x = 0; x <= dimensions.width - sprite.width; x++) {
+                    for (y = 0; y <= dimensions.height - sprite.height; y++) {
+                        sprite.x = x;
+                        sprite.y = y;
 
-                    intersection = this.intersection(sprite, placed);
+                        intersection = this.intersection(sprite, placed);
 
-                    if (!intersection) {
-                        placed.push(sprite);
-                        sprite.show();
-                        return true;
+                        if (!intersection) {
+                            placed.push(sprite);
+                            sprite.show();
+                            return true;
+                        }
+                        
+                        y = intersection.y + intersection.height - 1;
                     }
-
-                    y = intersection.y + intersection.height - 1;
+                    
+                    x = intersection.x + intersection.width - 1;
                 }
 
                 dimensions.width += sprite.width;
@@ -98,6 +119,22 @@ function ($, util, BaseLayout) {
             }
 
             return false;
+        },
+        
+        /**
+         * ### @isLimitable
+         * Returns whether rows/colums in layout are limitable
+         */
+        isLimitable : function() {
+            return true;
+        },
+        
+        /**
+         * ### @setLimit
+         * Limit the number of rows
+         */
+        setLimit : function(limit) {
+            this.rowlimit = limit;
         }
     });
 

--- a/src/js/layout/vertical.js
+++ b/src/js/layout/vertical.js
@@ -55,12 +55,14 @@ function ($, util, BaseLayout) {
                 i = 0, 
                 j =0;
                 
-            if(rows>0) {
+            if(rows>0 && rows<sprites.length) {
                 cols = Math.ceil(sprites.length/rows);
                 for(i=0; i<cols; i++) {
                     for(j=0; j<rows; j++) {
-                        if(sprites[i*rows+j])
-                        minheight += sprites[i*rows+j].height; 
+                        if(sprites[i*rows+j]) {
+                            minheight += sprites[i*rows+j].height; 
+                            width += sprites[i*rows+j].width;
+                        }
                     }
                     height = Math.max(height, minheight);
                     minheight = 0;    
@@ -70,7 +72,7 @@ function ($, util, BaseLayout) {
                 width = sprite.width > width ? sprite.width : width;
                 height += sprite.height;
             });
-
+console.log(width, height, sprites.length, this.rowlimit);
             return {
                 width: width || defaults.width,
                 height: height || defaults.height
@@ -93,7 +95,7 @@ function ($, util, BaseLayout) {
             var pass = 0;
             var x = 0;
             var y = 0;
-
+console.log(sprite.name);
             while (pass++ < this.settings.maxPass) {
                 for (x = 0; x <= dimensions.width - sprite.width; x++) {
                     for (y = 0; y <= dimensions.height - sprite.height; y++) {
@@ -101,7 +103,7 @@ function ($, util, BaseLayout) {
                         sprite.y = y;
 
                         intersection = this.intersection(sprite, placed);
-
+console.log("-",$(intersection).attr("name"));
                         if (!intersection) {
                             placed.push(sprite);
                             sprite.show();

--- a/src/js/manager/layout.js
+++ b/src/js/manager/layout.js
@@ -39,6 +39,26 @@ function ($, CompactLayout, VerticalLayout, HorizontalLayout) {
 
             this.manager = new Manager();
         },
+        /**
+         * ### @isLimitable
+         * Returns whether working layout manager is limitable
+         *
+         * @param null
+         */
+        isLimitable: function () {
+            return this.manager.isLimitable();
+        },
+        /**
+         * ### @limitRows
+         * Set the working layout manager instance by type
+         *
+         * @param {number} limit value for the limit 
+         */
+        setLimit: function (limit) {
+            if(this.manager.isLimitable()) {
+                this.manager.setLimit(limit);
+            }
+        },
 
         /**
          * ### @getDimensions

--- a/src/js/module/stitches.js
+++ b/src/js/module/stitches.js
@@ -165,6 +165,7 @@ function($, Modernizr, store, util, templates, fileManager, layoutManager, style
             });
             layoutManager.set(this.settings.layout);
             stylesheetManager.set(this.settings.stylesheet);
+            this.updateProps();
         },
 
         /**
@@ -289,6 +290,8 @@ function($, Modernizr, store, util, templates, fileManager, layoutManager, style
                             this.source.layout = value;
                             layoutManager.set(value);
                             self.updateSettings();
+                            layoutManager.setLimit(
+                                this.$element.find("input[name=limit]").val());
                         }
                     },
                     limit: {
@@ -811,6 +814,7 @@ function($, Modernizr, store, util, templates, fileManager, layoutManager, style
 
             // update settings
             layoutManager.set(this.settings.layout);
+            layoutManager.setLimit(this.settings.limit);
             stylesheetManager.set(this.settings.stylesheet);
             this.updateSettings();
 

--- a/src/js/module/stitches.js
+++ b/src/js/module/stitches.js
@@ -286,10 +286,16 @@ function($, Modernizr, store, util, templates, fileManager, layoutManager, style
                         "change": function (e) {
                             var $checked = this.$element.find("input[name=layout]:checked");
                             var value = $checked.val();
-
                             this.source.layout = value;
                             layoutManager.set(value);
-
+                            self.updateSettings();
+                        }
+                    },
+                    limit: {
+                        "change": function (e) {
+                            var value = $(e.currentTarget).val();
+                            self.settings.limit = value;
+                            layoutManager.setLimit(value);
                             self.updateSettings();
                         }
                     },
@@ -416,6 +422,7 @@ function($, Modernizr, store, util, templates, fileManager, layoutManager, style
             // update ui
             this.showOverlay();
             this.canvas.reset();
+            this.updateProps();
 
             // store settings
             if (store && !store.disabled) {
@@ -441,6 +448,17 @@ function($, Modernizr, store, util, templates, fileManager, layoutManager, style
          */
         hideOverlay: function (e) {
             this.$overlay.fadeOut("fast");
+        },
+        
+        /**
+         * ### @updateProps
+         * Update Dependent Properties
+         *
+         * @param {event} e The event object
+         */
+        updateProps: function (e) {
+            this.$element.find("input[name=limit]")
+                .prop('disabled', !layoutManager.isLimitable());
         },
 
         /**

--- a/src/templates/stitches.tpl
+++ b/src/templates/stitches.tpl
@@ -88,6 +88,14 @@
                                         </label>
                                     </div>
                                 </div>
+                                
+
+                                <div class="control-group">
+                                    <label class="control-label">Fixed Limit</label>
+                                    <div class="controls">
+                                        <input name="limit" disabled type="number" placeholder="Limit of rows/columns...">
+                                    </div>
+                                </div>
 
                                 <div class="control-group">
                                     <label class="control-label">CSS/LESS</label>


### PR DESCRIPTION
We cannot currently generate an x,y kind of spritesheet. This update allows to do so, by limiting the row or column in their respective layouts. 

Also, the placement in the compact layout is non sequential & hence cannot be used as is without it's stylesheet. A fixed Horizontal / Vertical placement can reduce the overhead of parsing a stylesheet, in certain cases. 
